### PR TITLE
warn players before stopping the container

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -120,7 +120,7 @@ fi
 
 
 function stop {
-	arkmanager stop
+	arkmanager stop --warn
 	exit 0
 }
 

--- a/run.sh
+++ b/run.sh
@@ -120,7 +120,9 @@ fi
 
 
 function stop {
-	arkmanager stop --warn
+	arkmanager broadcast "Server is shutting down"
+	arkmanager notify "Server is shutting down"
+	arkmanager stop
 	exit 0
 }
 


### PR DESCRIPTION
I wasn't sure if everyone wanted this.

This pull request will add a --warn to the stop function. This will warn players when you're stopping the container, rather than stopping the whole server without a warning.