### PR TITLE
Support for ARK cluster + shared server files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+ARG AMG_VERSION=latest
 FROM thmhoag/steamcmd:latest
 
 USER root
@@ -10,7 +11,11 @@ RUN apt-get update \
     && rm -rf /tmp/* \
     && rm -rf /var/tmp/*
 
-RUN curl -sL https://git.io/arkmanager | bash -s steam && \
+RUN (if [ $AMG_VERSION = "latest" ]; then \
+      curl -sL "https://git.io/arkmanager"; \
+    else \
+      curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/$AMG_VERSION/netinstall.sh"; \
+    fi) | bash -s steam && \
     ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
 
 COPY arkmanager/arkmanager.cfg /etc/arkmanager/arkmanager.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && rm -rf /tmp/* \
     && rm -rf /var/tmp/*
 
-RUN curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/v1.6.57/netinstall.sh" | bash -s steam && \
+RUN curl -sL https://git.io/arkmanager | bash -s steam && \
     ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
 
 COPY arkmanager/arkmanager.cfg /etc/arkmanager/arkmanager.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ ENV VALIDATE_SAVE_EXISTS=false \
 #    ARKSERVER_SHARED="/arkserver" \
     ARKCLUSTER=false
 
+VOLUME /home/steam/Steam
 VOLUME /ark
 # separate server files -> shared between servers in the cluster
 VOLUME /arkserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG STEAMCMD_VERSION=latest
 ARG AMG_BUILD=latest
 ARG AMG_VERSION=v1.6.57
-FROM drpsychick/steamcmd:$STEAMCMD_VERSION AS base
+FROM steamcmd/steamcmd:$STEAMCMD_VERSION AS base
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ ENV am_ark_SessionName=Ark\ Server \
     am_arkwarnminutes=15 \
     am_arkAutoUpdateOnStart=false
 #   am_ark_GameModIds= \
-#   am_ark_bRawSockets= \
 #   am_arkopt_clusterid=mycluster \
 #   am_arkflag_crossplay= \
 #   am_arkflag_NoTransferFromFiltering= \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,34 +28,35 @@ RUN echo "%sudo   ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers && \
 WORKDIR /home/steam
 USER steam
 
-ENV am_ark_SessionName="Ark Server" \
-    am_serverMap="TheIsland" \
-    am_ark_ServerAdminPassword="k3yb04rdc4t" \
-    am_ark_ServerPassword="" \
+ENV am_ark_SessionName=Ark\ Server \
+    am_serverMap=TheIsland \
+    am_ark_ServerAdminPassword=k3yb04rdc4t \
+#    am_ark_ServerPassword= \
     am_ark_MaxPlayers=70 \
     am_ark_QueryPort=27015 \
     am_ark_Port=7778 \
     am_ark_RCONPort=32330 \
-    am_ark_AltSaveDirectoryName="SavedArks" \
+    am_ark_AltSaveDirectoryName=SavedArks \
     am_arkwarnminutes=15 \
     am_arkAutoUpdateOnStart=false
-#   am_ark_GameModIds="" \
-#   am_ark_bRawSockets="" \
+#   am_ark_GameModIds= \
+#   am_ark_bRawSockets= \
 #   am_arkopt_clusterid=mycluster \
-#   am_arkflag_crossplay="" \
-#   am_arkflag_NoTransferFromFiltering="" \
-#   am_arkflag_servergamelog="" \
-#   am_arkflag_ForceAllowCaveFlyers="" \
+#   am_arkflag_crossplay= \
+#   am_arkflag_NoTransferFromFiltering= \
+#   am_arkflag_servergamelog= \
+#   am_arkflag_ForceAllowCaveFlyers= \
 
 ENV VALIDATE_SAVE_EXISTS=false \
     BACKUP_ONSTART=false \
     LOG_RCONCHAT=false \
     # ARKSERVER_SHARED requires to disable staging directory!
-#    am_arkStagingDir="" \
-#    ARKSERVER_SHARED="/arkserver" \
+#    am_arkStagingDir= \
+#    ARKSERVER_SHARED=/arkserver \
     ARKCLUSTER=false
 
-VOLUME /home/steam/Steam
+# only mount the steamapps directory
+VOLUME /home/steam/.steam/steamapps
 VOLUME /ark
 # separate server files -> shared between servers in the cluster
 VOLUME /arkserver

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ USER steam
 ENV am_ark_SessionName=Ark\ Server \
     am_serverMap=TheIsland \
     am_ark_ServerAdminPassword=k3yb04rdc4t \
-#    am_ark_ServerPassword= \
     am_ark_MaxPlayers=70 \
     am_ark_QueryPort=27015 \
     am_ark_Port=7778 \
@@ -39,25 +38,16 @@ ENV am_ark_SessionName=Ark\ Server \
     am_ark_AltSaveDirectoryName=SavedArks \
     am_arkwarnminutes=15 \
     am_arkAutoUpdateOnStart=false
-#   am_ark_GameModIds= \
-#   am_arkopt_clusterid=mycluster \
-#   am_arkflag_crossplay= \
-#   am_arkflag_NoTransferFromFiltering= \
-#   am_arkflag_servergamelog= \
-#   am_arkflag_ForceAllowCaveFlyers= \
 
 ENV VALIDATE_SAVE_EXISTS=false \
     BACKUP_ONSTART=false \
-    LOG_RCONCHAT=false \
-    # ARKSERVER_SHARED requires to disable staging directory!
-#    am_arkStagingDir= \
-#    ARKSERVER_SHARED=/arkserver \
+    LOG_RCONCHAT=0 \
     ARKCLUSTER=false
 
 # only mount the steamapps directory
 VOLUME /home/steam/.steam/steamapps
 VOLUME /ark
-# separate server files -> shared between servers in the cluster
+# optionally shared volumes between servers in a cluster
 VOLUME /arkserver
 VOLUME /arkclusters
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
+ARG STEAMCMD_VERSION=latest
 ARG AMG_BUILD=latest
 ARG AMG_VERSION=v1.6.57
-FROM thmhoag/steamcmd:latest AS base
+FROM thmhoag/steamcmd:$STEAMCMD_VERSION AS base
 
 USER root
 
@@ -15,8 +16,8 @@ RUN apt-get update \
 FROM base AS arkmanager-latest
 RUN curl -sL "https://git.io/arkmanager" | bash -s steam
 
-ARG AMG_VERSION
 FROM base AS arkmanager-versioned
+ARG AMG_VERSION
 RUN curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/$AMG_VERSION/netinstall.sh" | bash -s steam
 
 ARG AMG_BUILD

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ RUN apt-get update \
 FROM base AS arkmanager-latest
 RUN curl -sL "https://git.io/arkmanager" | bash -s steam
 
+ARG AMG_VERSION
 FROM base AS arkmanager-versioned
 RUN curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/$AMG_VERSION/netinstall.sh" | bash -s steam
 
+ARG AMG_BUILD
 FROM arkmanager-$AMG_BUILD
 RUN ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ ENV am_ark_SessionName="Ark Server" \
 ENV VALIDATE_SAVE_EXISTS=false \
     BACKUP_ONSTART=false \
     LOG_RCONCHAT=false \
+    # ARKSERVER_SHARED requires to disable staging directory!
+#    am_ark_arkStagingDir="" \
 #    ARKSERVER_SHARED="/arkserver" \
     ARKCLUSTER=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,13 @@ FROM thmhoag/steamcmd:latest
 
 USER root
 
-RUN apt-get update && \
-    apt-get install -y curl cron bzip2 perl-modules lsof libc6-i386 lib32gcc1 sudo
+RUN apt-get update \
+    && apt-get install -y curl cron bzip2 perl-modules lsof libc6-i386 lib32gcc1 sudo \
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
+    && rm -rf /var/tmp/*
 
 RUN curl -sL "https://raw.githubusercontent.com/FezVrasta/ark-server-tools/v1.6.54/netinstall.sh" | bash -s steam && \
     ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
@@ -26,12 +31,26 @@ USER steam
 ENV am_ark_SessionName="Ark Server" \
     am_serverMap="TheIsland" \
     am_ark_ServerAdminPassword="k3yb04rdc4t" \
+    am_ark_ServerPassword="" \
     am_ark_MaxPlayers=70 \
     am_ark_QueryPort=27015 \
     am_ark_Port=7778 \
     am_ark_RCONPort=32330 \
-    am_arkwarnminutes=15
+#    am_ark_AltSaveDirectoryName="SavedArks" \
+    am_arkwarnminutes=15 \
+    am_arkflag_crossplay=false \
+    am_ark_GameModIds="" \
+    am_arkAutoUpdateOnStart=false
+
+ENV VALIDATE_SAVE_EXISTS=false \
+    BACKUP_ONSTART=false \
+    LOG_RCONCHAT=false \
+    ARKCLUSTER=false
 
 VOLUME /ark
+# separate server files -> shared between servers in the cluster
+#VOLUME /arkserver
+#ENV am_arkserverroot="/arkserver"
+VOLUME /arkclusters
 
 CMD [ "./run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG STEAMCMD_VERSION=latest
 ARG AMG_BUILD=latest
 ARG AMG_VERSION=v1.6.57
-FROM steamcmd/steamcmd:$STEAMCMD_VERSION AS base
+FROM drpsychick/steamcmd:$STEAMCMD_VERSION AS base
 
 USER root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ ENV VALIDATE_SAVE_EXISTS=false \
     BACKUP_ONSTART=false \
     LOG_RCONCHAT=false \
     # ARKSERVER_SHARED requires to disable staging directory!
-#    am_ark_arkStagingDir="" \
+#    am_arkStagingDir="" \
 #    ARKSERVER_SHARED="/arkserver" \
     ARKCLUSTER=false
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,21 @@
 ARG STEAMCMD_VERSION=latest
 ARG AMG_BUILD=latest
 ARG AMG_VERSION=v1.6.57
-FROM thmhoag/steamcmd:$STEAMCMD_VERSION AS base
+FROM drpsychick/steamcmd:$STEAMCMD_VERSION AS base
 
 USER root
 
 RUN apt-get update \
-    && apt-get install -y curl cron bzip2 perl-modules lsof libc6-i386 lib32gcc1 sudo \
+    && apt-get install -y \
+    curl \
+    cron \
+    bzip2 \
+    perl-modules \
+    lsof \
+    libc6-i386 \
+    lib32gcc1 \
+    libsdl2-2.0.0:i386 \
+    sudo \
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/* \
@@ -60,6 +69,7 @@ VOLUME /home/steam/.steam/steamapps
 VOLUME /ark
 # optionally shared volumes between servers in a cluster
 VOLUME /arkserver
-VOLUME /arkclusters
+# mount /arkserver/ShooterGame/Saved seperate for each server
+# mount /arkserver/ShooterGame/Saved/clusters shared for all servers
 
 CMD [ "./run.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-ARG AMG_VERSION=latest
-FROM thmhoag/steamcmd:latest
+ARG AMG_BUILD=latest
+ARG AMG_VERSION=v1.6.57
+FROM thmhoag/steamcmd:latest AS base
 
 USER root
 
@@ -11,12 +12,14 @@ RUN apt-get update \
     && rm -rf /tmp/* \
     && rm -rf /var/tmp/*
 
-RUN (if [ $AMG_VERSION = "latest" ]; then \
-      curl -sL "https://git.io/arkmanager"; \
-    else \
-      curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/$AMG_VERSION/netinstall.sh"; \
-    fi) | bash -s steam && \
-    ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
+FROM base AS arkmanager-latest
+RUN curl -sL "https://git.io/arkmanager" | bash -s steam
+
+FROM base AS arkmanager-versioned
+RUN curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/$AMG_VERSION/netinstall.sh" | bash -s steam
+
+FROM arkmanager-$AMG_BUILD
+RUN ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
 
 COPY arkmanager/arkmanager.cfg /etc/arkmanager/arkmanager.cfg
 COPY arkmanager/instance.cfg /etc/arkmanager/instances/main.cfg

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && rm -rf /tmp/* \
     && rm -rf /var/tmp/*
 
-RUN curl -sL "https://raw.githubusercontent.com/FezVrasta/ark-server-tools/v1.6.54/netinstall.sh" | bash -s steam && \
+RUN curl -sL "https://raw.githubusercontent.com/arkmanager/ark-server-tools/v1.6.57/netinstall.sh" | bash -s steam && \
     ln -s /usr/local/bin/arkmanager /usr/bin/arkmanager
 
 COPY arkmanager/arkmanager.cfg /etc/arkmanager/arkmanager.cfg
@@ -36,21 +36,26 @@ ENV am_ark_SessionName="Ark Server" \
     am_ark_QueryPort=27015 \
     am_ark_Port=7778 \
     am_ark_RCONPort=32330 \
-#    am_ark_AltSaveDirectoryName="SavedArks" \
+    am_ark_AltSaveDirectoryName="SavedArks" \
     am_arkwarnminutes=15 \
-    am_arkflag_crossplay=false \
-    am_ark_GameModIds="" \
     am_arkAutoUpdateOnStart=false
+#   am_ark_GameModIds="" \
+#   am_ark_bRawSockets="" \
+#   am_arkopt_clusterid=mycluster \
+#   am_arkflag_crossplay="" \
+#   am_arkflag_NoTransferFromFiltering="" \
+#   am_arkflag_servergamelog="" \
+#   am_arkflag_ForceAllowCaveFlyers="" \
 
 ENV VALIDATE_SAVE_EXISTS=false \
     BACKUP_ONSTART=false \
     LOG_RCONCHAT=false \
+#    ARKSERVER_SHARED="/arkserver" \
     ARKCLUSTER=false
 
 VOLUME /ark
 # separate server files -> shared between servers in the cluster
-#VOLUME /arkserver
-#ENV am_arkserverroot="/arkserver"
+VOLUME /arkserver
 VOLUME /arkclusters
 
 CMD [ "./run.sh" ]

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ store identical files twice on disk.
 
 Example: (using the .env files in `/test`)
 ```shell script
-IMAGE=thmhoag/arkcluster
+IMAGE=thmhoag/arkserver
 TAG=bionic
 mkdir -p theisland ragnarok arkserver arkclusters theisland/saved ragnarok/saved
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ mkdir -p theisland ragnarok arkserver arkclusters theisland/saved ragnarok/saved
 
 # start server 1
 serverdir=theisland
-docker run -it --name $serverdir \
+docker run --rm -it --name $serverdir \
   --env-file test/ark-$serverdir.env \
   -v $PWD/$serverdir:/ark \
   -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
@@ -140,13 +140,13 @@ docker run -it --name $serverdir \
 # start server 2
 # using the SAME `arkserver` and `arkclusters` directory
 serverdir=ragnarok
-docker run -it --name $serverdir \
+docker run --rm -it --name $serverdir \
   --env-file test/ark-$serverdir.env \
   -v $PWD/$serverdir:/ark \
   -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
   -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
   -v $PWD/arkserver:/arkserver \
-  -p 27015:27016/udp -p 7780:7780/udp -p 32331:32331 \
+  -p 27016:27016/udp -p 7780:7780/udp -p 32331:32331 \
   $IMAGE:$TAG
 
 # now you can reach your servers on 27015 and 27016 respectively

--- a/README.md
+++ b/README.md
@@ -156,3 +156,13 @@ docker run --rm -it --name $serverdir \
 # cleanup
 rm -rf theisland ragnarok arkserver arkclusters
 ```
+
+To test jumping from one server to another:
+* join one server, enable cheats with `enablecheats <adminpassword>`
+* cheat your character the transmitter tek engram `cheat GiveTekengramsTo <survivorID> transmitter`
+* cheat your character a transmitter item `cheat gfi TekTransmitter 1 1 0`
+* place the transmitter, turn it on, enter the inventory -> you should see "travel to another server" button in the middle
+* click it and select the server you want to travel to
+
+The `survivorID` is the number displayed when you hover over the specimen implant (diamond shaped item) 
+you always have (https://ark.fandom.com/wiki/Specimen_Implant). 

--- a/README.md
+++ b/README.md
@@ -115,8 +115,10 @@ Inside the `/ark` volume there are several directories containing server related
 | /ark/staging | Default directory for staging game and mod updates. Can be changed using in `arkmanager.cfg` |
 
 ## Running a cluster
-In order to run an ARK cluster, all you need are multiple servers sharing the `clusters` directory - and a lot of RAM.
-Additionally you can share the server files, so that all servers use the same version and you don't have to store identical files twice on disk.
+In order to run an ARK cluster, all you need are multiple servers sharing the `clusters` directory and using a shared, 
+unique `clusterid` - and a lot of RAM.
+Additionally you can share the server files, so that all servers use the same version and you don't have to 
+store identical files twice on disk.
 
 Example: (using the .env files in `/test`)
 ```shell script
@@ -124,7 +126,7 @@ IMAGE=thmhoag/arkcluster
 TAG=bionic
 mkdir -p theisland ragnarok arkserver arkclusters theisland/saved ragnarok/saved
 
-# start server 1
+# start server 1 with am_arkAutoUpdateOnStart=true
 serverdir=theisland
 docker run --rm -it --name $serverdir \
   --env-file test/ark-$serverdir.env \
@@ -137,7 +139,7 @@ docker run --rm -it --name $serverdir \
 
 # wait for the server to be up, it should download all mods and the game
 
-# start server 2
+# start server 2+ with am_arkAutoUpdateOnStart=false
 # using the SAME `arkserver` and `arkclusters` directory
 serverdir=ragnarok
 docker run --rm -it --name $serverdir \

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ A set of required environment variables have default values provided as part of 
 | am_ark_RCONPort | `32330` | RCON port |
 | am_arkwarnminutes | `15` | Number of minutes to wait/warn players before updating/restarting |
 | am_arkflag_crossplay | `false` | Allow crossyplay with Players on Epic |
-| ARKCLUSTER | `false` | Symlinks `ShooterGame/Saved/clusters` to the `/arkclusters` volume |
-| ARKSERVER_SHARED | `` | To optionally share server binary files, use `/arkserver` volume |
+| ARKCLUSTER | `false` | If true, requires `ShooterGame/Saved/clusters` to be mounted |
+| ARKSERVER_SHARED | `` | To optionally share server binary files, use `/arkserver` volume, see below |
 | LOG_RCONCHAT | `0` | Fetch chat commands every X seconds and log them to stdout, `0` = disabled |
 
 ### Adding Additional Variables
@@ -98,8 +98,9 @@ The optional volumes can be used to share the server binary files or `clusters` 
 | - | - |
 | /home/steam/.steam/steamapps | Directory of steamapps and workshop files. Should be mounted so that mod installs are persisted between container runs/restarts |
 | /ark | Directory that will contain the server files, config files, logs and backups. More information below |
-| /arkclusters | (optional) Directory that contains the shared cluster files required to jump from one ARK server to another |
-| /arkserver | (optional) Directory that contains the server binary files from steam, shared for multiple instances |
+| /arkserver | (optional, $ARKSERVER_SHARED) Directory that contains the server binary files from steam, shared for multiple instances |
+| /arkserver/ShooterGame/Saved | (depends) Directory that contains the game save files - must be mounted if using shared server files |
+| /arkserver/ShooterGame/Saved/clusters | (depends) Directory that contains the shared cluster files required to jump from one ARK server to another - must be mounted if using shared server files |
 
 ### Subdirectories of /ark
 
@@ -112,4 +113,3 @@ Inside the `/ark` volume there are several directories containing server related
 | /ark/log | Location of the arkmanager and arkserver log files |
 | /ark/server | Location of the server installation performed by `steamcmd`. This will contain the ShooterGame directory and the actual server binaries. |
 | /ark/staging | Default directory for staging game and mod updates. Can be changed using in `arkmanager.cfg` |
-| /ark/saved | Location of the `Saved` directory of a server instance |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker pull thmhoag/arkserver:latest
 To run a generic server with no configuration modifications:
 ```bash
 $ docker run -d \
-    -v steam:/home/steam/Steam \  # mounted so that workshop (mod) downloads are persisted
+    -v steam:/home/steam/.steam/steamapps \  # mounted so that workshop (mod) downloads are persisted
     -v ark:/ark \  # mounted as the directory to contain the server/backup/log/config files
     -p 27015:27015 -p 27015:27015/udp \  # steam query port
     -p 7778:7778 -p 7778:7778/udp \  # gameserver port

--- a/README.md
+++ b/README.md
@@ -69,21 +69,37 @@ A set of required environment variables have default values provided as part of 
 | am_ark_RCONPort | `32330` | RCON port |
 | am_arkwarnminutes | `15` | Number of minutes to wait/warn players before updating/restarting |
 | am_arkflag_crossplay | `false` | Allow crossyplay with Players on Epic |
+| ARKCLUSTER | `false` | Symlinks `ShooterGame/Saved/clusters` to the `/arkclusters` volume |
+| ARKSERVER_SHARED | `` | To optionally share server binary files, use `/arkserver` volume |
+| LOG_RCONCHAT | `0` | Fetch chat commands every X seconds and log them to stdout, `0` = disabled |
 
 ### Adding Additional Variables
 
 Any configuration value that is available via `arkmanager` can be set using an environment variable. This works by taking any environment variable on the container that is prefixed with `am_` and mapping it to the corresponding environment variable in the `arkmanager.cfg` file. 
 
-For a complete list of configuration values available, please see [FezVrasta](https://github.com/FezVrasta)'s great documentation here: [arkmanager Configuration Files](https://github.com/FezVrasta/ark-server-tools#configuration-files)
+For a complete list of configuration values available, please see [FezVrasta](https://github.com/arkmanager)'s great documentation here: [arkmanager Configuration Files](https://github.com/arkmanager/ark-server-tools#configuration-files)
+
+Some examples:
+```shell script
+am_ark_ServerPassword=s3cr3t
+am_ark_GameModIds=889745138,731604991
+am_arkopt_clusterid=mycluster
+am_arkflag_NoTransferFromFiltering=
+am_arkflag_servergamelog=
+am_arkflag_ForceAllowCaveFlyers=
+```
 
 ## Volumes
 
 This image has two main volumes that should be mounted as named volumes or host directories for the persistence of the server install and all related configuration files. More information on Docker volumes here: [Docker: Use Volumes](https://docs.docker.com/storage/volumes/)
+The optional volumes can be used to share the server binary files or `clusters` files required to run an ARK cluster and be able to jump from one map to another. 
 
 | Path | Description |
 | - | - |
-| /home/steam/Steam | Directory of steam cache and other steamcmd-related files. Should be mounted so that mod installs are persisted between container runs/restarts |
+| /home/steam/.steam/steamapps | Directory of steamapps and workshop files. Should be mounted so that mod installs are persisted between container runs/restarts |
 | /ark | Directory that will contain the server files, config files, logs and backups. More information below |
+| /arkclusters | (optional) Directory that contains the shared cluster files required to jump from one ARK server to another |
+| /arkserver | (optional) Directory that contains the server binary files from steam, shared for multiple instances |
 
 ### Subdirectories of /ark
 
@@ -96,3 +112,4 @@ Inside the `/ark` volume there are several directories containing server related
 | /ark/log | Location of the arkmanager and arkserver log files |
 | /ark/server | Location of the server installation performed by `steamcmd`. This will contain the ShooterGame directory and the actual server binaries. |
 | /ark/staging | Default directory for staging game and mod updates. Can be changed using in `arkmanager.cfg` |
+| /ark/saved | Location of the `Saved` directory of a server instance |

--- a/log.sh
+++ b/log.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 while true; do
-  sleep 1
+  sleep 5
   arkmanager rconcmd GetChat 2>/dev/null | sed '/^Running command.*$/d' | tr -d '"' | sed '/^\s*$/d' | sed '/^Command processed.*$/d' | sed '/^Error connecting to server.*$/d'
 done

--- a/log.sh
+++ b/log.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 while true; do
-  sleep 5
+  sleep $LOG_RCONCHAT
   arkmanager rconcmd GetChat 2>/dev/null | sed '/^Running command.*$/d' | tr -d '"' | sed '/^\s*$/d' | sed '/^Command processed.*$/d' | sed '/^Error connecting to server.*$/d'
 done

--- a/run.sh
+++ b/run.sh
@@ -42,7 +42,7 @@ fi
 echo -e "\n\narkserverroot=\"/ark/server\"\n" >> /ark/config/arkmanager.cfg
 printenv | sed -n -r 's/am_(.*)=(.*)/\1=\"\2\"/ip' >> /ark/config/arkmanager.cfg
 
-if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" ]; then
+if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" -a ! -L /ark/server ]; then
   # migration: move files
   if [ ! -f $ARKSERVER_SHARED/ShooterGame/Binaries/Linux/ShooterGameServer -a -f /ark/server/ShooterGame/Binaries/Linux/ShooterGameServer ]; then
     mv /ark/server/* $ARKSERVER_SHARED/

--- a/run.sh
+++ b/run.sh
@@ -112,6 +112,11 @@ else
 	echo "Save file validation is not enabled."
 fi
 
+if [[ "$ARKCLUSTER" = true ]]; then
+  # link shared cluster directory
+  ln -sf /arkclusters /ark/server/ShooterGame/Saved/clusters
+fi
+
 if [[ $BACKUP_ONSTART = true ]]; then
 	echo "Backing up on start..."
 	arkmanager backup
@@ -131,9 +136,10 @@ function stop {
 trap stop INT
 trap stop TERM
 
-# TODO: Provide IF statement here with ENV variable
-# to allow server logs to be scraped from RCON to stdout
-# bash -c ./log.sh &
+# log from RCON to stdout
+if [[ $LOG_RCONCHAT = true ]]; then
+  bash -c ./log.sh &
+fi
 
 arkmanager start --no-background --verbose &
 arkmanpid=$!

--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,7 @@ echo "Cleaning up any leftover arkmanager files..."
 [ ! -d /ark/log ] && mkdir /ark/log
 [ ! -d /ark/backup ] && mkdir /ark/backup
 [ ! -d /ark/staging ] && mkdir /ark/staging
+[ ! -d /ark/$am_ark_AltSaveDirectoryName ] && mkdir /ark/$am_ark_AltSaveDirectoryName
 
 echo "Creating arkmanager.cfg from environment variables..."
 echo -e "# Ark Server Tools - arkmanager config\n# Generated from container environment variables\n\n" > /ark/config/arkmanager.cfg

--- a/run.sh
+++ b/run.sh
@@ -32,11 +32,11 @@ fi
 if [ "$ARKCLUSTER" = "true" ]; then
   # directory is created when something is mounted to 'clusters'
   [ -d "$ARKSERVER/ShooterGame/Saved" ] && chown steam:steam $ARKSERVER/ShooterGame/Saved
-  echo "Shared clusters files in $ARKSERVER_SHARED/ShooterGame/Saved/clusters..."
-  if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved/clusters ")" ]; then
+  echo "Shared clusters files in $ARKSERVER/ShooterGame/Saved/clusters..."
+  if [ -z "$(mount | grep "on $ARKSERVER/ShooterGame/Saved/clusters ")" ]; then
     echo "===> ABORT !"
     echo "You seem to using ARKCLUSTER=true"
-    echo "But you have NOT mounted your shared clusters directory to '$ARKSERVER_SHARED/ShooterGame/Saved/clusters'"
+    echo "But you have NOT mounted your shared clusters directory to '$ARKSERVER/ShooterGame/Saved/clusters'"
     exit 1
   fi
 fi

--- a/run.sh
+++ b/run.sh
@@ -25,6 +25,8 @@ if [ -n "$ARKSERVER_SHARED" ]; then
     echo "But you have NOT mounted your game instance saved directory to '$ARKSERVER_SHARED/ShooterGame/Saved'"
     exit 1
   fi
+  # Shared server files does not support staging directory
+  export am_arkStagingDir=
 fi
 
 if [ "$ARKCLUSTER" = "true" ]; then

--- a/run.sh
+++ b/run.sh
@@ -32,6 +32,12 @@ echo "Cleaning up any leftover arkmanager files..."
 [ ! -d /ark/backup ] && mkdir /ark/backup
 [ ! -d /ark/staging ] && mkdir /ark/staging
 [ ! -d /ark/saved ] && mkdir /ark/saved
+
+# migrate to new directory structure
+if [ -d /ark/server/ShooterGame/Saved ]; then
+  # move to /ark/saved
+  mv /ark/server/ShooterGame/Saved/* /ark/saved/ && ln -sf /ark/saved /ark/server/ShooterGame/Saved
+fi
 [ ! -d /ark/saved/$am_ark_AltSaveDirectoryName ] && mkdir /ark/saved/$am_ark_AltSaveDirectoryName
 
 echo "Creating arkmanager.cfg from environment variables..."

--- a/run.sh
+++ b/run.sh
@@ -31,7 +31,7 @@ fi
 
 if [ "$ARKCLUSTER" = "true" ]; then
   # directory is created when something is mounted to 'clusters'
-  [ -d "$ARKSERVER_SHARED/ShooterGame/Saved" ] && chown steam:steam $ARKSERVER_SHARED/ShooterGame/Saved
+  [ -d "$ARKSERVER/ShooterGame/Saved" ] && chown steam:steam $ARKSERVER/ShooterGame/Saved
   echo "Shared clusters files in $ARKSERVER_SHARED/ShooterGame/Saved/clusters..."
   if [ -z "$(mount | grep "on $ARKSERVER_SHARED/ShooterGame/Saved/clusters ")" ]; then
     echo "===> ABORT !"

--- a/run.sh
+++ b/run.sh
@@ -46,17 +46,21 @@ if [ -f /ark/config/arkmanager_base.cfg ]; then
 	cat /ark/config/arkmanager_base.cfg >> /ark/config/arkmanager.cfg
 fi
 
+if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" ]; then
+  if [ ! -L /ark/server ]; then
+    # migration: move files
+    if [ ! -f $ARKSERVER_SHARED/ShooterGame/Binaries/Linux/ShooterGameServer -a -f /ark/server/ShooterGame/Binaries/Linux/ShooterGameServer ]; then
+      mv /ark/server/* $ARKSERVER_SHARED/
+    fi
+    # shared server files in this directory
+    ln -sf $ARKSERVER_SHARED /ark/server
+  fi
+  # shared server files requires disabling staging
+  export am_arkStagingDir=
+fi
+
 echo -e "\n\narkserverroot=\"/ark/server\"\n" >> /ark/config/arkmanager.cfg
 printenv | sed -n -r 's/am_(.*)=(.*)/\1=\"\2\"/ip' >> /ark/config/arkmanager.cfg
-
-if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" -a ! -L /ark/server ]; then
-  # migration: move files
-  if [ ! -f $ARKSERVER_SHARED/ShooterGame/Binaries/Linux/ShooterGameServer -a -f /ark/server/ShooterGame/Binaries/Linux/ShooterGameServer ]; then
-    mv /ark/server/* $ARKSERVER_SHARED/
-  fi
-  # shared server files in this directory
-  ln -sf $ARKSERVER_SHARED /ark/server
-fi
 
 if [ ! -d /ark/server/ShooterGame ]; then
 	echo "No game files found. Installing..."
@@ -156,7 +160,7 @@ trap stop INT
 trap stop TERM
 
 # log from RCON to stdout
-if [[ $LOG_RCONCHAT = true ]]; then
+if [ $LOG_RCONCHAT -gt 0 ]; then
   bash -c ./log.sh &
 fi
 

--- a/run.sh
+++ b/run.sh
@@ -51,7 +51,7 @@ if [ -n "$ARKSERVER_SHARED" -a -d "$ARKSERVER_SHARED" -a ! -L /ark/server ]; the
   ln -sf $ARKSERVER_SHARED /ark/server
 fi
 
-if [ ! -d /ark/server -o ! -f /ark/server/ShooterGame/Binaries/Linux/ShooterGameServer ]; then
+if [ ! -d /ark/server/ShooterGame ]; then
 	echo "No game files found. Installing..."
 	mkdir -p /ark/server/ShooterGame/Saved/Config/LinuxServer
 	mkdir -p /ark/server/ShooterGame/Content/Mods

--- a/test/ark-ragnarok.env
+++ b/test/ark-ragnarok.env
@@ -1,3 +1,4 @@
+am_arkNoPortDecrement=true
 am_ark_SessionName=Ark Server
 am_serverMap=Ragnarok
 am_ark_ServerAdminPassword=k3yb04rdc4t
@@ -7,7 +8,7 @@ am_ark_QueryPort=27016
 am_ark_Port=7780
 am_ark_RCONPort=32331
 #am_arkwarnminutes=15
-am_arkAutoUpdateOnStart=true
+am_arkAutoUpdateOnStart=false
 am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
 ARKCLUSTER=true
 ARKSERVER_SHARED=/arkserver

--- a/test/ark-ragnarok.env
+++ b/test/ark-ragnarok.env
@@ -11,4 +11,6 @@ am_ark_RCONPort=32331
 am_arkAutoUpdateOnStart=false
 am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
 ARKCLUSTER=true
+# this must be unique across all clusters on steam!
+am_arkopt_clusterid=FooBar
 ARKSERVER_SHARED=/arkserver

--- a/test/ark-ragnarok.env
+++ b/test/ark-ragnarok.env
@@ -1,11 +1,11 @@
 am_ark_SessionName=Ark Server
-am_serverMap=TheIsland
+am_serverMap=Ragnarok
 am_ark_ServerAdminPassword=k3yb04rdc4t
 am_ark_ServerPassword=
 am_ark_MaxPlayers=10
-am_ark_QueryPort=27015
-am_ark_Port=7778
-am_ark_RCONPort=32330
+am_ark_QueryPort=27016
+am_ark_Port=7780
+am_ark_RCONPort=32331
 #am_arkwarnminutes=15
 am_arkAutoUpdateOnStart=true
 am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190

--- a/test/ark-thecenter.env
+++ b/test/ark-thecenter.env
@@ -1,0 +1,15 @@
+am_ark_SessionName=Ark Server
+am_serverMap=TheCenter
+am_ark_ServerAdminPassword=k3yb04rdc4t
+am_ark_ServerPassword=
+am_ark_MaxPlayers=10
+am_ark_QueryPort=27015
+am_ark_Port=7778
+am_ark_RCONPort=32330
+#am_ark_AltSaveDirectoryName=SavedArks
+#am_arkwarnminutes=15
+#am_arkAutoUpdateOnStart=false
+am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
+#ARKCLUSTER=true
+#am_arkStagingDir=
+#ARKSERVER_SHARED=/arkserver

--- a/test/ark-theisland.env
+++ b/test/ark-theisland.env
@@ -1,0 +1,15 @@
+am_ark_SessionName=Ark Server
+am_serverMap=TheIsland
+am_ark_ServerAdminPassword=k3yb04rdc4t
+am_ark_ServerPassword=
+am_ark_MaxPlayers=10
+am_ark_QueryPort=27015
+am_ark_Port=7778
+am_ark_RCONPort=32330
+#am_ark_AltSaveDirectoryName=SavedArks
+#am_arkwarnminutes=15
+am_arkAutoUpdateOnStart=true
+am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
+ARKCLUSTER=true
+ARKSERVER_SHARED=/arkserver
+#am_arkStagingDir=

--- a/test/ark-theisland.env
+++ b/test/ark-theisland.env
@@ -1,3 +1,4 @@
+am_arkNoPortDecrement=true
 am_ark_SessionName=Ark Server
 am_serverMap=TheIsland
 am_ark_ServerAdminPassword=k3yb04rdc4t

--- a/test/ark-theisland.env
+++ b/test/ark-theisland.env
@@ -11,4 +11,6 @@ am_ark_RCONPort=32330
 am_arkAutoUpdateOnStart=true
 am_ark_GameModIds=889745138,731604991,893904615,564895376,931434275,1404697612,621154190
 ARKCLUSTER=true
+# this must be unique across all clusters on steam!
+am_arkopt_clusterid=FooBar
 ARKSERVER_SHARED=/arkserver

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+
+IMAGE=drpsychick/arkcluster
+TAG=focal
+(cd ..; docker build --build-arg STEAMCMD_VERSION=$TAG --tag $IMAGE:$TAG .)
+#docker pull $IMAGE:$TAG
+
+function testDirectoriesExist() {
+  nok=0
+  if [ ! -d "$1/backup" ]; then nok=$((nok+1)); echo "/backup is missing!"; fi
+  if [ ! -d "$1/config" ]; then nok=$((nok+1)); echo "/config is missing!"; fi
+  if [ ! -d "$1/log" ]; then nok=$((nok+1)); echo "/log is missing!"; fi
+
+  if [ $nok -gt 0 ]; then
+    echo "FAIL: $nok errors"
+  fi
+}
+
+function testNewSimpleServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -e ARKCLUSTER=false \
+    -e ARKSERVER_SHARED= \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland
+}
+
+function testNewSharedServerFail() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/arkclusters:/arkclusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -eq 0 ] && echo "FAIL: docker failure expected!"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+function testNewSharedServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland/saved arkserver arkclusters
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker failed!"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+function testMigratedServer() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+  mkdir -p ark-theisland/server/ShooterGame/Binaries
+  mkdir -p ark-theisland/server/ShooterGame/Saved/SavedArks
+  mkdir -p ark-theisland/saved/SavedArks
+  touch ark-theisland/server/ShooterGame/Saved/SavedArks/savegame-dead.dat
+  touch ark-theisland/saved/SavedArks/savegame-good.dat
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+###
+function testSharedMount() {
+  echo "====> TEST $FUNCNAME"
+  mkdir -p ark-theisland arkserver arkclusters
+  mkdir -p ark-theisland/server/ShooterGame/Binaries
+  mkdir -p ark-theisland/saved/SavedArks
+  touch ark-theisland/saved/SavedArks/savegame.dat
+
+  serverdir=ark-theisland
+  docker run --rm -it --name $serverdir \
+    --env-file $serverdir.env \
+    -v $PWD/$serverdir:/ark \
+    -v $PWD/$serverdir/saved:/arkserver/ShooterGame/Saved \
+    -v $PWD/arkclusters:/arkserver/ShooterGame/Saved/clusters \
+    -v $PWD/arkserver:/arkserver \
+    -e LIST_MOUNTS=true \
+    $IMAGE:$TAG
+  [ $? -ne 0 ] && echo "FAIL: docker exec failed"
+
+  testDirectoriesExist $serverdir
+
+  rm -rf ark-theisland arkserver arkclusters
+}
+
+testNewSimpleServer
+testNewSharedServerFail
+testNewSharedServer
+testMigratedServer
+testSharedMount
+


### PR DESCRIPTION
* update arkmanager version & url
* symlink `Saved` to individual server (to support shared server files, because arkmanager puts PID files in `Saved`)
* shared server files requires disabling staging directory
* always set `am_ark_AltSaveDirectoryName` and create directory
* new variables
  * LOG_RCONCHAT, ARKCLUSTER, ARKSERVER_SHARED
* switch README to LF

@thmhoag I'm happy to make some adjustments if this PR does not work for you